### PR TITLE
fix: Add error property to theme

### DIFF
--- a/gh-dash.tera
+++ b/gh-dash.tera
@@ -14,8 +14,9 @@ theme:
       secondary: "#{{ palette[accent].hex }}"
       inverted: "#{{ palette.crust.hex }}"
       faint: "#{{ palette.subtext1.hex }}"
-      warning: "#{{ palette.red.hex }}"
+      warning: "#{{ palette.yellow.hex }}"
       success: "#{{ palette.green.hex }}"
+      error: "#{{ palette.red.hex }}"
     background:
       selected: "#{{palette.surface0.hex }}"
     border:

--- a/themes/frappe/catppuccin-frappe-blue.yml
+++ b/themes/frappe/catppuccin-frappe-blue.yml
@@ -5,8 +5,9 @@ theme:
       secondary: "#8caaee"
       inverted: "#232634"
       faint: "#b5bfe2"
-      warning: "#e78284"
+      warning: "#e5c890"
       success: "#a6d189"
+      error: "#e78284"
     background:
       selected: "#414559"
     border:

--- a/themes/frappe/catppuccin-frappe-flamingo.yml
+++ b/themes/frappe/catppuccin-frappe-flamingo.yml
@@ -5,8 +5,9 @@ theme:
       secondary: "#eebebe"
       inverted: "#232634"
       faint: "#b5bfe2"
-      warning: "#e78284"
+      warning: "#e5c890"
       success: "#a6d189"
+      error: "#e78284"
     background:
       selected: "#414559"
     border:

--- a/themes/frappe/catppuccin-frappe-green.yml
+++ b/themes/frappe/catppuccin-frappe-green.yml
@@ -5,8 +5,9 @@ theme:
       secondary: "#a6d189"
       inverted: "#232634"
       faint: "#b5bfe2"
-      warning: "#e78284"
+      warning: "#e5c890"
       success: "#a6d189"
+      error: "#e78284"
     background:
       selected: "#414559"
     border:

--- a/themes/frappe/catppuccin-frappe-lavender.yml
+++ b/themes/frappe/catppuccin-frappe-lavender.yml
@@ -5,8 +5,9 @@ theme:
       secondary: "#babbf1"
       inverted: "#232634"
       faint: "#b5bfe2"
-      warning: "#e78284"
+      warning: "#e5c890"
       success: "#a6d189"
+      error: "#e78284"
     background:
       selected: "#414559"
     border:

--- a/themes/frappe/catppuccin-frappe-maroon.yml
+++ b/themes/frappe/catppuccin-frappe-maroon.yml
@@ -5,8 +5,9 @@ theme:
       secondary: "#ea999c"
       inverted: "#232634"
       faint: "#b5bfe2"
-      warning: "#e78284"
+      warning: "#e5c890"
       success: "#a6d189"
+      error: "#e78284"
     background:
       selected: "#414559"
     border:

--- a/themes/frappe/catppuccin-frappe-mauve.yml
+++ b/themes/frappe/catppuccin-frappe-mauve.yml
@@ -5,8 +5,9 @@ theme:
       secondary: "#ca9ee6"
       inverted: "#232634"
       faint: "#b5bfe2"
-      warning: "#e78284"
+      warning: "#e5c890"
       success: "#a6d189"
+      error: "#e78284"
     background:
       selected: "#414559"
     border:

--- a/themes/frappe/catppuccin-frappe-peach.yml
+++ b/themes/frappe/catppuccin-frappe-peach.yml
@@ -5,8 +5,9 @@ theme:
       secondary: "#ef9f76"
       inverted: "#232634"
       faint: "#b5bfe2"
-      warning: "#e78284"
+      warning: "#e5c890"
       success: "#a6d189"
+      error: "#e78284"
     background:
       selected: "#414559"
     border:

--- a/themes/frappe/catppuccin-frappe-pink.yml
+++ b/themes/frappe/catppuccin-frappe-pink.yml
@@ -5,8 +5,9 @@ theme:
       secondary: "#f4b8e4"
       inverted: "#232634"
       faint: "#b5bfe2"
-      warning: "#e78284"
+      warning: "#e5c890"
       success: "#a6d189"
+      error: "#e78284"
     background:
       selected: "#414559"
     border:

--- a/themes/frappe/catppuccin-frappe-red.yml
+++ b/themes/frappe/catppuccin-frappe-red.yml
@@ -5,8 +5,9 @@ theme:
       secondary: "#e78284"
       inverted: "#232634"
       faint: "#b5bfe2"
-      warning: "#e78284"
+      warning: "#e5c890"
       success: "#a6d189"
+      error: "#e78284"
     background:
       selected: "#414559"
     border:

--- a/themes/frappe/catppuccin-frappe-rosewater.yml
+++ b/themes/frappe/catppuccin-frappe-rosewater.yml
@@ -5,8 +5,9 @@ theme:
       secondary: "#f2d5cf"
       inverted: "#232634"
       faint: "#b5bfe2"
-      warning: "#e78284"
+      warning: "#e5c890"
       success: "#a6d189"
+      error: "#e78284"
     background:
       selected: "#414559"
     border:

--- a/themes/frappe/catppuccin-frappe-sapphire.yml
+++ b/themes/frappe/catppuccin-frappe-sapphire.yml
@@ -5,8 +5,9 @@ theme:
       secondary: "#85c1dc"
       inverted: "#232634"
       faint: "#b5bfe2"
-      warning: "#e78284"
+      warning: "#e5c890"
       success: "#a6d189"
+      error: "#e78284"
     background:
       selected: "#414559"
     border:

--- a/themes/frappe/catppuccin-frappe-sky.yml
+++ b/themes/frappe/catppuccin-frappe-sky.yml
@@ -5,8 +5,9 @@ theme:
       secondary: "#99d1db"
       inverted: "#232634"
       faint: "#b5bfe2"
-      warning: "#e78284"
+      warning: "#e5c890"
       success: "#a6d189"
+      error: "#e78284"
     background:
       selected: "#414559"
     border:

--- a/themes/frappe/catppuccin-frappe-teal.yml
+++ b/themes/frappe/catppuccin-frappe-teal.yml
@@ -5,8 +5,9 @@ theme:
       secondary: "#81c8be"
       inverted: "#232634"
       faint: "#b5bfe2"
-      warning: "#e78284"
+      warning: "#e5c890"
       success: "#a6d189"
+      error: "#e78284"
     background:
       selected: "#414559"
     border:

--- a/themes/frappe/catppuccin-frappe-yellow.yml
+++ b/themes/frappe/catppuccin-frappe-yellow.yml
@@ -5,8 +5,9 @@ theme:
       secondary: "#e5c890"
       inverted: "#232634"
       faint: "#b5bfe2"
-      warning: "#e78284"
+      warning: "#e5c890"
       success: "#a6d189"
+      error: "#e78284"
     background:
       selected: "#414559"
     border:

--- a/themes/latte/catppuccin-latte-blue.yml
+++ b/themes/latte/catppuccin-latte-blue.yml
@@ -5,8 +5,9 @@ theme:
       secondary: "#1e66f5"
       inverted: "#dce0e8"
       faint: "#5c5f77"
-      warning: "#d20f39"
+      warning: "#df8e1d"
       success: "#40a02b"
+      error: "#d20f39"
     background:
       selected: "#ccd0da"
     border:

--- a/themes/latte/catppuccin-latte-flamingo.yml
+++ b/themes/latte/catppuccin-latte-flamingo.yml
@@ -5,8 +5,9 @@ theme:
       secondary: "#dd7878"
       inverted: "#dce0e8"
       faint: "#5c5f77"
-      warning: "#d20f39"
+      warning: "#df8e1d"
       success: "#40a02b"
+      error: "#d20f39"
     background:
       selected: "#ccd0da"
     border:

--- a/themes/latte/catppuccin-latte-green.yml
+++ b/themes/latte/catppuccin-latte-green.yml
@@ -5,8 +5,9 @@ theme:
       secondary: "#40a02b"
       inverted: "#dce0e8"
       faint: "#5c5f77"
-      warning: "#d20f39"
+      warning: "#df8e1d"
       success: "#40a02b"
+      error: "#d20f39"
     background:
       selected: "#ccd0da"
     border:

--- a/themes/latte/catppuccin-latte-lavender.yml
+++ b/themes/latte/catppuccin-latte-lavender.yml
@@ -5,8 +5,9 @@ theme:
       secondary: "#7287fd"
       inverted: "#dce0e8"
       faint: "#5c5f77"
-      warning: "#d20f39"
+      warning: "#df8e1d"
       success: "#40a02b"
+      error: "#d20f39"
     background:
       selected: "#ccd0da"
     border:

--- a/themes/latte/catppuccin-latte-maroon.yml
+++ b/themes/latte/catppuccin-latte-maroon.yml
@@ -5,8 +5,9 @@ theme:
       secondary: "#e64553"
       inverted: "#dce0e8"
       faint: "#5c5f77"
-      warning: "#d20f39"
+      warning: "#df8e1d"
       success: "#40a02b"
+      error: "#d20f39"
     background:
       selected: "#ccd0da"
     border:

--- a/themes/latte/catppuccin-latte-mauve.yml
+++ b/themes/latte/catppuccin-latte-mauve.yml
@@ -5,8 +5,9 @@ theme:
       secondary: "#8839ef"
       inverted: "#dce0e8"
       faint: "#5c5f77"
-      warning: "#d20f39"
+      warning: "#df8e1d"
       success: "#40a02b"
+      error: "#d20f39"
     background:
       selected: "#ccd0da"
     border:

--- a/themes/latte/catppuccin-latte-peach.yml
+++ b/themes/latte/catppuccin-latte-peach.yml
@@ -5,8 +5,9 @@ theme:
       secondary: "#fe640b"
       inverted: "#dce0e8"
       faint: "#5c5f77"
-      warning: "#d20f39"
+      warning: "#df8e1d"
       success: "#40a02b"
+      error: "#d20f39"
     background:
       selected: "#ccd0da"
     border:

--- a/themes/latte/catppuccin-latte-pink.yml
+++ b/themes/latte/catppuccin-latte-pink.yml
@@ -5,8 +5,9 @@ theme:
       secondary: "#ea76cb"
       inverted: "#dce0e8"
       faint: "#5c5f77"
-      warning: "#d20f39"
+      warning: "#df8e1d"
       success: "#40a02b"
+      error: "#d20f39"
     background:
       selected: "#ccd0da"
     border:

--- a/themes/latte/catppuccin-latte-red.yml
+++ b/themes/latte/catppuccin-latte-red.yml
@@ -5,8 +5,9 @@ theme:
       secondary: "#d20f39"
       inverted: "#dce0e8"
       faint: "#5c5f77"
-      warning: "#d20f39"
+      warning: "#df8e1d"
       success: "#40a02b"
+      error: "#d20f39"
     background:
       selected: "#ccd0da"
     border:

--- a/themes/latte/catppuccin-latte-rosewater.yml
+++ b/themes/latte/catppuccin-latte-rosewater.yml
@@ -5,8 +5,9 @@ theme:
       secondary: "#dc8a78"
       inverted: "#dce0e8"
       faint: "#5c5f77"
-      warning: "#d20f39"
+      warning: "#df8e1d"
       success: "#40a02b"
+      error: "#d20f39"
     background:
       selected: "#ccd0da"
     border:

--- a/themes/latte/catppuccin-latte-sapphire.yml
+++ b/themes/latte/catppuccin-latte-sapphire.yml
@@ -5,8 +5,9 @@ theme:
       secondary: "#209fb5"
       inverted: "#dce0e8"
       faint: "#5c5f77"
-      warning: "#d20f39"
+      warning: "#df8e1d"
       success: "#40a02b"
+      error: "#d20f39"
     background:
       selected: "#ccd0da"
     border:

--- a/themes/latte/catppuccin-latte-sky.yml
+++ b/themes/latte/catppuccin-latte-sky.yml
@@ -5,8 +5,9 @@ theme:
       secondary: "#04a5e5"
       inverted: "#dce0e8"
       faint: "#5c5f77"
-      warning: "#d20f39"
+      warning: "#df8e1d"
       success: "#40a02b"
+      error: "#d20f39"
     background:
       selected: "#ccd0da"
     border:

--- a/themes/latte/catppuccin-latte-teal.yml
+++ b/themes/latte/catppuccin-latte-teal.yml
@@ -5,8 +5,9 @@ theme:
       secondary: "#179299"
       inverted: "#dce0e8"
       faint: "#5c5f77"
-      warning: "#d20f39"
+      warning: "#df8e1d"
       success: "#40a02b"
+      error: "#d20f39"
     background:
       selected: "#ccd0da"
     border:

--- a/themes/latte/catppuccin-latte-yellow.yml
+++ b/themes/latte/catppuccin-latte-yellow.yml
@@ -5,8 +5,9 @@ theme:
       secondary: "#df8e1d"
       inverted: "#dce0e8"
       faint: "#5c5f77"
-      warning: "#d20f39"
+      warning: "#df8e1d"
       success: "#40a02b"
+      error: "#d20f39"
     background:
       selected: "#ccd0da"
     border:

--- a/themes/macchiato/catppuccin-macchiato-blue.yml
+++ b/themes/macchiato/catppuccin-macchiato-blue.yml
@@ -5,8 +5,9 @@ theme:
       secondary: "#8aadf4"
       inverted: "#181926"
       faint: "#b8c0e0"
-      warning: "#ed8796"
+      warning: "#eed49f"
       success: "#a6da95"
+      error: "#ed8796"
     background:
       selected: "#363a4f"
     border:

--- a/themes/macchiato/catppuccin-macchiato-flamingo.yml
+++ b/themes/macchiato/catppuccin-macchiato-flamingo.yml
@@ -5,8 +5,9 @@ theme:
       secondary: "#f0c6c6"
       inverted: "#181926"
       faint: "#b8c0e0"
-      warning: "#ed8796"
+      warning: "#eed49f"
       success: "#a6da95"
+      error: "#ed8796"
     background:
       selected: "#363a4f"
     border:

--- a/themes/macchiato/catppuccin-macchiato-green.yml
+++ b/themes/macchiato/catppuccin-macchiato-green.yml
@@ -5,8 +5,9 @@ theme:
       secondary: "#a6da95"
       inverted: "#181926"
       faint: "#b8c0e0"
-      warning: "#ed8796"
+      warning: "#eed49f"
       success: "#a6da95"
+      error: "#ed8796"
     background:
       selected: "#363a4f"
     border:

--- a/themes/macchiato/catppuccin-macchiato-lavender.yml
+++ b/themes/macchiato/catppuccin-macchiato-lavender.yml
@@ -5,8 +5,9 @@ theme:
       secondary: "#b7bdf8"
       inverted: "#181926"
       faint: "#b8c0e0"
-      warning: "#ed8796"
+      warning: "#eed49f"
       success: "#a6da95"
+      error: "#ed8796"
     background:
       selected: "#363a4f"
     border:

--- a/themes/macchiato/catppuccin-macchiato-maroon.yml
+++ b/themes/macchiato/catppuccin-macchiato-maroon.yml
@@ -5,8 +5,9 @@ theme:
       secondary: "#ee99a0"
       inverted: "#181926"
       faint: "#b8c0e0"
-      warning: "#ed8796"
+      warning: "#eed49f"
       success: "#a6da95"
+      error: "#ed8796"
     background:
       selected: "#363a4f"
     border:

--- a/themes/macchiato/catppuccin-macchiato-mauve.yml
+++ b/themes/macchiato/catppuccin-macchiato-mauve.yml
@@ -5,8 +5,9 @@ theme:
       secondary: "#c6a0f6"
       inverted: "#181926"
       faint: "#b8c0e0"
-      warning: "#ed8796"
+      warning: "#eed49f"
       success: "#a6da95"
+      error: "#ed8796"
     background:
       selected: "#363a4f"
     border:

--- a/themes/macchiato/catppuccin-macchiato-peach.yml
+++ b/themes/macchiato/catppuccin-macchiato-peach.yml
@@ -5,8 +5,9 @@ theme:
       secondary: "#f5a97f"
       inverted: "#181926"
       faint: "#b8c0e0"
-      warning: "#ed8796"
+      warning: "#eed49f"
       success: "#a6da95"
+      error: "#ed8796"
     background:
       selected: "#363a4f"
     border:

--- a/themes/macchiato/catppuccin-macchiato-pink.yml
+++ b/themes/macchiato/catppuccin-macchiato-pink.yml
@@ -5,8 +5,9 @@ theme:
       secondary: "#f5bde6"
       inverted: "#181926"
       faint: "#b8c0e0"
-      warning: "#ed8796"
+      warning: "#eed49f"
       success: "#a6da95"
+      error: "#ed8796"
     background:
       selected: "#363a4f"
     border:

--- a/themes/macchiato/catppuccin-macchiato-red.yml
+++ b/themes/macchiato/catppuccin-macchiato-red.yml
@@ -5,8 +5,9 @@ theme:
       secondary: "#ed8796"
       inverted: "#181926"
       faint: "#b8c0e0"
-      warning: "#ed8796"
+      warning: "#eed49f"
       success: "#a6da95"
+      error: "#ed8796"
     background:
       selected: "#363a4f"
     border:

--- a/themes/macchiato/catppuccin-macchiato-rosewater.yml
+++ b/themes/macchiato/catppuccin-macchiato-rosewater.yml
@@ -5,8 +5,9 @@ theme:
       secondary: "#f4dbd6"
       inverted: "#181926"
       faint: "#b8c0e0"
-      warning: "#ed8796"
+      warning: "#eed49f"
       success: "#a6da95"
+      error: "#ed8796"
     background:
       selected: "#363a4f"
     border:

--- a/themes/macchiato/catppuccin-macchiato-sapphire.yml
+++ b/themes/macchiato/catppuccin-macchiato-sapphire.yml
@@ -5,8 +5,9 @@ theme:
       secondary: "#7dc4e4"
       inverted: "#181926"
       faint: "#b8c0e0"
-      warning: "#ed8796"
+      warning: "#eed49f"
       success: "#a6da95"
+      error: "#ed8796"
     background:
       selected: "#363a4f"
     border:

--- a/themes/macchiato/catppuccin-macchiato-sky.yml
+++ b/themes/macchiato/catppuccin-macchiato-sky.yml
@@ -5,8 +5,9 @@ theme:
       secondary: "#91d7e3"
       inverted: "#181926"
       faint: "#b8c0e0"
-      warning: "#ed8796"
+      warning: "#eed49f"
       success: "#a6da95"
+      error: "#ed8796"
     background:
       selected: "#363a4f"
     border:

--- a/themes/macchiato/catppuccin-macchiato-teal.yml
+++ b/themes/macchiato/catppuccin-macchiato-teal.yml
@@ -5,8 +5,9 @@ theme:
       secondary: "#8bd5ca"
       inverted: "#181926"
       faint: "#b8c0e0"
-      warning: "#ed8796"
+      warning: "#eed49f"
       success: "#a6da95"
+      error: "#ed8796"
     background:
       selected: "#363a4f"
     border:

--- a/themes/macchiato/catppuccin-macchiato-yellow.yml
+++ b/themes/macchiato/catppuccin-macchiato-yellow.yml
@@ -5,8 +5,9 @@ theme:
       secondary: "#eed49f"
       inverted: "#181926"
       faint: "#b8c0e0"
-      warning: "#ed8796"
+      warning: "#eed49f"
       success: "#a6da95"
+      error: "#ed8796"
     background:
       selected: "#363a4f"
     border:

--- a/themes/mocha/catppuccin-mocha-blue.yml
+++ b/themes/mocha/catppuccin-mocha-blue.yml
@@ -5,8 +5,9 @@ theme:
       secondary: "#89b4fa"
       inverted: "#11111b"
       faint: "#bac2de"
-      warning: "#f38ba8"
+      warning: "#f9e2af"
       success: "#a6e3a1"
+      error: "#f38ba8"
     background:
       selected: "#313244"
     border:

--- a/themes/mocha/catppuccin-mocha-flamingo.yml
+++ b/themes/mocha/catppuccin-mocha-flamingo.yml
@@ -5,8 +5,9 @@ theme:
       secondary: "#f2cdcd"
       inverted: "#11111b"
       faint: "#bac2de"
-      warning: "#f38ba8"
+      warning: "#f9e2af"
       success: "#a6e3a1"
+      error: "#f38ba8"
     background:
       selected: "#313244"
     border:

--- a/themes/mocha/catppuccin-mocha-green.yml
+++ b/themes/mocha/catppuccin-mocha-green.yml
@@ -5,8 +5,9 @@ theme:
       secondary: "#a6e3a1"
       inverted: "#11111b"
       faint: "#bac2de"
-      warning: "#f38ba8"
+      warning: "#f9e2af"
       success: "#a6e3a1"
+      error: "#f38ba8"
     background:
       selected: "#313244"
     border:

--- a/themes/mocha/catppuccin-mocha-lavender.yml
+++ b/themes/mocha/catppuccin-mocha-lavender.yml
@@ -5,8 +5,9 @@ theme:
       secondary: "#b4befe"
       inverted: "#11111b"
       faint: "#bac2de"
-      warning: "#f38ba8"
+      warning: "#f9e2af"
       success: "#a6e3a1"
+      error: "#f38ba8"
     background:
       selected: "#313244"
     border:

--- a/themes/mocha/catppuccin-mocha-maroon.yml
+++ b/themes/mocha/catppuccin-mocha-maroon.yml
@@ -5,8 +5,9 @@ theme:
       secondary: "#eba0ac"
       inverted: "#11111b"
       faint: "#bac2de"
-      warning: "#f38ba8"
+      warning: "#f9e2af"
       success: "#a6e3a1"
+      error: "#f38ba8"
     background:
       selected: "#313244"
     border:

--- a/themes/mocha/catppuccin-mocha-mauve.yml
+++ b/themes/mocha/catppuccin-mocha-mauve.yml
@@ -5,8 +5,9 @@ theme:
       secondary: "#cba6f7"
       inverted: "#11111b"
       faint: "#bac2de"
-      warning: "#f38ba8"
+      warning: "#f9e2af"
       success: "#a6e3a1"
+      error: "#f38ba8"
     background:
       selected: "#313244"
     border:

--- a/themes/mocha/catppuccin-mocha-peach.yml
+++ b/themes/mocha/catppuccin-mocha-peach.yml
@@ -5,8 +5,9 @@ theme:
       secondary: "#fab387"
       inverted: "#11111b"
       faint: "#bac2de"
-      warning: "#f38ba8"
+      warning: "#f9e2af"
       success: "#a6e3a1"
+      error: "#f38ba8"
     background:
       selected: "#313244"
     border:

--- a/themes/mocha/catppuccin-mocha-pink.yml
+++ b/themes/mocha/catppuccin-mocha-pink.yml
@@ -5,8 +5,9 @@ theme:
       secondary: "#f5c2e7"
       inverted: "#11111b"
       faint: "#bac2de"
-      warning: "#f38ba8"
+      warning: "#f9e2af"
       success: "#a6e3a1"
+      error: "#f38ba8"
     background:
       selected: "#313244"
     border:

--- a/themes/mocha/catppuccin-mocha-red.yml
+++ b/themes/mocha/catppuccin-mocha-red.yml
@@ -5,8 +5,9 @@ theme:
       secondary: "#f38ba8"
       inverted: "#11111b"
       faint: "#bac2de"
-      warning: "#f38ba8"
+      warning: "#f9e2af"
       success: "#a6e3a1"
+      error: "#f38ba8"
     background:
       selected: "#313244"
     border:

--- a/themes/mocha/catppuccin-mocha-rosewater.yml
+++ b/themes/mocha/catppuccin-mocha-rosewater.yml
@@ -5,8 +5,9 @@ theme:
       secondary: "#f5e0dc"
       inverted: "#11111b"
       faint: "#bac2de"
-      warning: "#f38ba8"
+      warning: "#f9e2af"
       success: "#a6e3a1"
+      error: "#f38ba8"
     background:
       selected: "#313244"
     border:

--- a/themes/mocha/catppuccin-mocha-sapphire.yml
+++ b/themes/mocha/catppuccin-mocha-sapphire.yml
@@ -5,8 +5,9 @@ theme:
       secondary: "#74c7ec"
       inverted: "#11111b"
       faint: "#bac2de"
-      warning: "#f38ba8"
+      warning: "#f9e2af"
       success: "#a6e3a1"
+      error: "#f38ba8"
     background:
       selected: "#313244"
     border:

--- a/themes/mocha/catppuccin-mocha-sky.yml
+++ b/themes/mocha/catppuccin-mocha-sky.yml
@@ -5,8 +5,9 @@ theme:
       secondary: "#89dceb"
       inverted: "#11111b"
       faint: "#bac2de"
-      warning: "#f38ba8"
+      warning: "#f9e2af"
       success: "#a6e3a1"
+      error: "#f38ba8"
     background:
       selected: "#313244"
     border:

--- a/themes/mocha/catppuccin-mocha-teal.yml
+++ b/themes/mocha/catppuccin-mocha-teal.yml
@@ -5,8 +5,9 @@ theme:
       secondary: "#94e2d5"
       inverted: "#11111b"
       faint: "#bac2de"
-      warning: "#f38ba8"
+      warning: "#f9e2af"
       success: "#a6e3a1"
+      error: "#f38ba8"
     background:
       selected: "#313244"
     border:

--- a/themes/mocha/catppuccin-mocha-yellow.yml
+++ b/themes/mocha/catppuccin-mocha-yellow.yml
@@ -5,8 +5,9 @@ theme:
       secondary: "#f9e2af"
       inverted: "#11111b"
       faint: "#bac2de"
-      warning: "#f38ba8"
+      warning: "#f9e2af"
       success: "#a6e3a1"
+      error: "#f38ba8"
     background:
       selected: "#313244"
     border:


### PR DESCRIPTION
Looks like dlvhdr/gh-dash#458 added a new `error` property to the
`theme:colors:text` stanza in the Yaml configuration. This patch fixes the theme
by including that property. I have a documentation change upstream that explains
the issue further that can be found here: dlvhdr/gh-dash#469.

## Changes

- [x] **fix: Adding error property;**
- [x] **chore: Building all theme files**
